### PR TITLE
feat: #5 인터뷰 ID 기반 질문-답변 조회 API 구현

### DIFF
--- a/src/main/java/com/graduation/interviewAi/controller/AnswerController.java
+++ b/src/main/java/com/graduation/interviewAi/controller/AnswerController.java
@@ -1,0 +1,22 @@
+package com.graduation.interviewAi.controller;
+
+import com.graduation.interviewAi.dto.AnswerWithQuestionDto;
+import com.graduation.interviewAi.service.AnswerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/answers")
+@RequiredArgsConstructor
+public class AnswerController {
+
+    private final AnswerService answerService;
+
+    // 인터뷰 ID로 답변 + 질문 정보 조회
+    @GetMapping("/interview/{interviewId}")
+    public List<AnswerWithQuestionDto> getAnswersByInterviewId(@PathVariable int interviewId) {
+        return answerService.getAnswersByInterviewId(interviewId);
+    }
+}

--- a/src/main/java/com/graduation/interviewAi/dto/AnswerWithQuestionDto.java
+++ b/src/main/java/com/graduation/interviewAi/dto/AnswerWithQuestionDto.java
@@ -1,0 +1,18 @@
+package com.graduation.interviewAi.dto;
+import lombok.Data;
+
+@Data
+public class AnswerWithQuestionDto {
+    // Answer 관련 필드
+    private int answerId;
+    private String acontent;
+    private int interviewId;
+
+    // Question 관련 필드
+    private int questionId;
+    private String qcontent;
+    private int category;
+    private int jobId;
+    private int interviewSourceId;
+}
+

--- a/src/main/java/com/graduation/interviewAi/dto/AnswerWithQuestionDto.java
+++ b/src/main/java/com/graduation/interviewAi/dto/AnswerWithQuestionDto.java
@@ -3,12 +3,10 @@ import lombok.Data;
 
 @Data
 public class AnswerWithQuestionDto {
-    // Answer 관련 필드
     private int answerId;
     private String acontent;
     private int interviewId;
 
-    // Question 관련 필드
     private int questionId;
     private String qcontent;
     private int category;

--- a/src/main/java/com/graduation/interviewAi/mapper/AnswerMapper.java
+++ b/src/main/java/com/graduation/interviewAi/mapper/AnswerMapper.java
@@ -2,8 +2,12 @@ package com.graduation.interviewAi.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import com.graduation.interviewAi.domain.Answer;
+import com.graduation.interviewAi.dto.AnswerWithQuestionDto;
+
+import java.util.List;
 
 @Mapper
 public interface AnswerMapper {
     void saveAnswer(Answer answer);
+    List<AnswerWithQuestionDto> findAnswersByInterviewId(int interviewId);
 }

--- a/src/main/java/com/graduation/interviewAi/service/AnswerService.java
+++ b/src/main/java/com/graduation/interviewAi/service/AnswerService.java
@@ -1,0 +1,19 @@
+package com.graduation.interviewAi.service;
+
+import com.graduation.interviewAi.dto.AnswerWithQuestionDto;
+import com.graduation.interviewAi.mapper.AnswerMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerService {
+
+    private final AnswerMapper answerMapper;
+
+    public List<AnswerWithQuestionDto> getAnswersByInterviewId(int interviewId) {
+        return answerMapper.findAnswersByInterviewId(interviewId);
+    }
+}

--- a/src/main/resources/mapper/AnswerMapper.xml
+++ b/src/main/resources/mapper/AnswerMapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.graduation.interviewAi.mapper.AnswerMapper">
+
+    <select id="findAnswersByInterviewId" resultType="com.graduation.interviewAi.dto.AnswerWithQuestionDto">
+        SELECT
+        a.answerId,
+        a.acontent,
+        a.interviewId,
+        q.questionId,
+        q.jobId,
+        q.category,
+        q.qcontent,
+        q.interview_source_id
+        FROM Answer a
+        JOIN Question q ON a.questionId = q.questionId
+        WHERE a.interviewId = #{interviewId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈
#5
인터뷰 ID 기반 질문-답변 조회 API 구현 

Answer 테이블과 Question 테이블을 조인해서 사용자의 인터뷰 id에 따른 질문-답변 쌍을 가져옴
답변 평가와 결과 화면, 홈 화면 내역 등에서 사용됨

## 📝작업 내용

- AnswerController.java
- AnswerWithQuestionDto.java
- AnswerMapper.java
- AnswerService.java
- AnswerMapper.xml

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
