### PR TITLE
feat: #18 카카오 로그인 프론트엔드 연동

### DIFF
--- a/src/main/java/com/graduation/interviewAi/controller/KakaoAuthController.java
+++ b/src/main/java/com/graduation/interviewAi/controller/KakaoAuthController.java
@@ -7,8 +7,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+import org.springframework.web.util.UriComponentsBuilder;
 import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,10 +35,16 @@ public class KakaoAuthController {
         KakaoUserDto user = kakaoAuthService.registerOrLoginWithCode(code);
         String token = jwtTokenService.generateToken(user);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("token", token);
-        response.put("user", user);
+        String redirectUrl = UriComponentsBuilder
+                .fromUriString("http://localhost:3000/kakao/redirect")
+                .queryParam("token", token)
+                .queryParam("userId", user.getUserId())
+                .queryParam("name", user.getName())
+                .build()
+                .toUriString();
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(redirectUrl))
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
카카오로그인 프론트엔드 연동


## 📝작업 내용

- 카카오 로그인 후 redirect url을 리액트 /kakao/redirect 페이지로 이동
- JWT 토큰 정보 및 사용자 정보 프론트로 전달 및 저장


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> _리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요_<br>
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
