### PR TITLE
feat: #16 이전 내역 조회

### DIFF
--- a/src/main/java/com/graduation/interviewAi/controller/ResultController.java
+++ b/src/main/java/com/graduation/interviewAi/controller/ResultController.java
@@ -1,0 +1,21 @@
+package com.graduation.interviewAi.controller;
+
+import com.graduation.interviewAi.dto.ScoreRecordsDto;
+import com.graduation.interviewAi.service.ResultService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/results")
+public class ResultController {
+
+    private final ResultService resultService;
+
+    @GetMapping("/{userId}")
+    public List<ScoreRecordsDto> getResultsByUser(@PathVariable Integer userId) {
+        return resultService.getScoreRecordsByUserId(userId);
+    }
+}

--- a/src/main/java/com/graduation/interviewAi/controller/ResultController.java
+++ b/src/main/java/com/graduation/interviewAi/controller/ResultController.java
@@ -1,5 +1,6 @@
 package com.graduation.interviewAi.controller;
 
+import com.graduation.interviewAi.dto.InterviewWithAnswersDto;
 import com.graduation.interviewAi.dto.ScoreRecordsDto;
 import com.graduation.interviewAi.service.ResultService;
 import lombok.RequiredArgsConstructor;
@@ -17,5 +18,10 @@ public class ResultController {
     @GetMapping("/{userId}")
     public List<ScoreRecordsDto> getResultsByUser(@PathVariable Integer userId) {
         return resultService.getScoreRecordsByUserId(userId);
+    }
+
+    @GetMapping("/{userId}/with-answers")
+    public List<InterviewWithAnswersDto> getInterviewsWithAnswers(@PathVariable Integer userId) {
+        return resultService.getAllRecordByUserId(userId);
     }
 }

--- a/src/main/java/com/graduation/interviewAi/dto/InterviewWithAnswersDto.java
+++ b/src/main/java/com/graduation/interviewAi/dto/InterviewWithAnswersDto.java
@@ -1,0 +1,17 @@
+package com.graduation.interviewAi.dto;
+
+import lombok.Data;
+
+import java.util.List;
+import java.sql.Timestamp;
+
+@Data
+public class InterviewWithAnswersDto {
+    private Integer interviewId;
+    private String company;
+    private Integer jobId;
+    private Integer resumeId;
+    private Timestamp createdAt;
+    private Integer userId;
+    private List<AnswerWithQuestionDto> answers;
+}

--- a/src/main/java/com/graduation/interviewAi/dto/InterviewWithJobDto.java
+++ b/src/main/java/com/graduation/interviewAi/dto/InterviewWithJobDto.java
@@ -1,12 +1,10 @@
 package com.graduation.interviewAi.dto;
 
 import lombok.Data;
-
-import java.util.List;
 import java.sql.Timestamp;
 
 @Data
-public class InterviewWithAnswersDto {
+public class InterviewWithJobDto {
     private Integer interviewId;
     private String company;
     private Integer jobId;
@@ -14,5 +12,4 @@ public class InterviewWithAnswersDto {
     private Integer resumeId;
     private Timestamp createdAt;
     private Integer userId;
-    private List<AnswerWithQuestionDto> answers;
 }

--- a/src/main/java/com/graduation/interviewAi/dto/ScoreRecordsDto.java
+++ b/src/main/java/com/graduation/interviewAi/dto/ScoreRecordsDto.java
@@ -1,0 +1,13 @@
+package com.graduation.interviewAi.dto;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class ScoreRecordsDto {
+    private Integer interviewId;
+    private Double simScore;
+    private Double logicScore;
+    private Double claScore;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/graduation/interviewAi/dto/ScoreRecordsDto.java
+++ b/src/main/java/com/graduation/interviewAi/dto/ScoreRecordsDto.java
@@ -1,6 +1,6 @@
 package com.graduation.interviewAi.dto;
 
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
 import lombok.Data;
 
 @Data
@@ -9,5 +9,5 @@ public class ScoreRecordsDto {
     private Double simScore;
     private Double logicScore;
     private Double claScore;
-    private LocalDateTime createdAt;
+    private Timestamp createdAt;
 }

--- a/src/main/java/com/graduation/interviewAi/mapper/InterviewMapper.java
+++ b/src/main/java/com/graduation/interviewAi/mapper/InterviewMapper.java
@@ -3,10 +3,13 @@ package com.graduation.interviewAi.mapper;
 import org.apache.ibatis.annotations.Mapper;
 import com.graduation.interviewAi.domain.Interview;
 
+import java.util.List;
+
 @Mapper
 public interface InterviewMapper {
     void insertInterview(Interview interview);
     Interview findInterviewById(Integer interviewId);
     Integer getResumeIdByInterviewId(Integer interviewId);
     Integer getJobIdByInterviewId(Integer interviewId);
+    List<Interview> findInterviewsByUserId(Integer interviewId);
 }

--- a/src/main/java/com/graduation/interviewAi/mapper/InterviewMapper.java
+++ b/src/main/java/com/graduation/interviewAi/mapper/InterviewMapper.java
@@ -1,5 +1,6 @@
 package com.graduation.interviewAi.mapper;
 
+import com.graduation.interviewAi.dto.InterviewWithJobDto;
 import org.apache.ibatis.annotations.Mapper;
 import com.graduation.interviewAi.domain.Interview;
 
@@ -11,5 +12,5 @@ public interface InterviewMapper {
     Interview findInterviewById(Integer interviewId);
     Integer getResumeIdByInterviewId(Integer interviewId);
     Integer getJobIdByInterviewId(Integer interviewId);
-    List<Interview> findInterviewsByUserId(Integer interviewId);
+    List<InterviewWithJobDto> findInterviewsByUserId(Integer interviewId);
 }

--- a/src/main/java/com/graduation/interviewAi/mapper/ResultMapper.java
+++ b/src/main/java/com/graduation/interviewAi/mapper/ResultMapper.java
@@ -1,6 +1,7 @@
 package com.graduation.interviewAi.mapper;
 
 import com.graduation.interviewAi.domain.Result;
+import com.graduation.interviewAi.dto.ScoreRecordsDto;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -9,4 +10,5 @@ import java.util.List;
 public interface ResultMapper {
     void saveResult(Result result);
     List<Result> findResultByInterviewId(int interviewId);
+    List<ScoreRecordsDto> findScoreRecordsByInterviewId(int interviewId);
 }

--- a/src/main/java/com/graduation/interviewAi/service/ResultService.java
+++ b/src/main/java/com/graduation/interviewAi/service/ResultService.java
@@ -1,10 +1,17 @@
 package com.graduation.interviewAi.service;
 
+import com.graduation.interviewAi.domain.Interview;
+import com.graduation.interviewAi.dto.AnswerWithQuestionDto;
 import com.graduation.interviewAi.dto.ScoreRecordsDto;
+import com.graduation.interviewAi.dto.InterviewWithAnswersDto;
+import com.graduation.interviewAi.mapper.AnswerMapper;
 import com.graduation.interviewAi.mapper.ResultMapper;
+import com.graduation.interviewAi.mapper.InterviewMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -12,8 +19,26 @@ import java.util.List;
 public class ResultService {
 
     private final ResultMapper resultMapper;
+    private final InterviewMapper interviewMapper;
+    private final AnswerMapper answerMapper;
 
     public List<ScoreRecordsDto> getScoreRecordsByUserId(Integer userId) {
         return resultMapper.findScoreRecordsByInterviewId(userId);
+    }
+
+    public List<InterviewWithAnswersDto> getAllRecordByUserId(Integer userId) {
+        List<Interview> interviews = interviewMapper.findInterviewsByUserId(userId);
+        List<InterviewWithAnswersDto> result = new ArrayList<>();
+
+        for (Interview interview : interviews) {
+            List<AnswerWithQuestionDto> answers = answerMapper.findAnswersByInterviewId(interview.getInterviewId());
+            InterviewWithAnswersDto dto = new InterviewWithAnswersDto();
+            BeanUtils.copyProperties(interview, dto); // 혹은 수동으로 복사
+            dto.setAnswers(answers);
+
+            result.add(dto);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/graduation/interviewAi/service/ResultService.java
+++ b/src/main/java/com/graduation/interviewAi/service/ResultService.java
@@ -1,0 +1,19 @@
+package com.graduation.interviewAi.service;
+
+import com.graduation.interviewAi.dto.ScoreRecordsDto;
+import com.graduation.interviewAi.mapper.ResultMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ResultService {
+
+    private final ResultMapper resultMapper;
+
+    public List<ScoreRecordsDto> getScoreRecordsByUserId(Integer userId) {
+        return resultMapper.findScoreRecordsByInterviewId(userId);
+    }
+}

--- a/src/main/java/com/graduation/interviewAi/service/ResultService.java
+++ b/src/main/java/com/graduation/interviewAi/service/ResultService.java
@@ -1,7 +1,7 @@
 package com.graduation.interviewAi.service;
 
-import com.graduation.interviewAi.domain.Interview;
 import com.graduation.interviewAi.dto.AnswerWithQuestionDto;
+import com.graduation.interviewAi.dto.InterviewWithJobDto;
 import com.graduation.interviewAi.dto.ScoreRecordsDto;
 import com.graduation.interviewAi.dto.InterviewWithAnswersDto;
 import com.graduation.interviewAi.mapper.AnswerMapper;
@@ -27,13 +27,13 @@ public class ResultService {
     }
 
     public List<InterviewWithAnswersDto> getAllRecordByUserId(Integer userId) {
-        List<Interview> interviews = interviewMapper.findInterviewsByUserId(userId);
+        List<InterviewWithJobDto> interviews = interviewMapper.findInterviewsByUserId(userId);
         List<InterviewWithAnswersDto> result = new ArrayList<>();
 
-        for (Interview interview : interviews) {
+        for (InterviewWithJobDto interview : interviews) {
             List<AnswerWithQuestionDto> answers = answerMapper.findAnswersByInterviewId(interview.getInterviewId());
             InterviewWithAnswersDto dto = new InterviewWithAnswersDto();
-            BeanUtils.copyProperties(interview, dto); // 혹은 수동으로 복사
+            BeanUtils.copyProperties(interview, dto);
             dto.setAnswers(answers);
 
             result.add(dto);

--- a/src/main/resources/mapper/AnswerMapper.xml
+++ b/src/main/resources/mapper/AnswerMapper.xml
@@ -24,7 +24,7 @@
         AND questionId = #{questionId}
     </update>
 
-    <!-- InterviewId 기반 QnA 내역 가져옴 -->
+    <!-- InterviewId 기반 QnA 내역 조회 -->
     <select id="findAnswersByInterviewId" resultType="com.graduation.interviewAi.dto.AnswerWithQuestionDto">
         SELECT
         a.answerId,

--- a/src/main/resources/mapper/InterviewMapper.xml
+++ b/src/main/resources/mapper/InterviewMapper.xml
@@ -29,18 +29,20 @@
         SELECT * FROM Interview WHERE interviewId = #{interviewId}
     </select>
 
-    <!-- userID 기반 인터뷰 내역 조회 -->
-    <select id="findInterviewsByUserId" resultType="com.graduation.interviewAi.domain.Interview">
+    <!-- userID 기반 인터뷰 내역 조회(직무포함) -->
+    <select id="findInterviewsByUserId" resultType="com.graduation.interviewAi.dto.InterviewWithJobDto">
         SELECT
-            interviewId,
-            company,
-            jobId,
-            resumeId,
-            date AS createdAt,
-            userId
-        FROM Interview
-        WHERE userId = #{userId}
-        ORDER BY date DESC
+            i.interviewId,
+            i.company,
+            i.jobId,
+            f.job,
+            i.resumeId,
+            i.date AS createdAt,
+            i.userId
+        FROM Interview i
+                 JOIN Field f ON i.jobId = f.jobId
+        WHERE i.userId = #{userId}
+        ORDER BY i.date DESC
     </select>
 
 

--- a/src/main/resources/mapper/InterviewMapper.xml
+++ b/src/main/resources/mapper/InterviewMapper.xml
@@ -29,4 +29,19 @@
         SELECT * FROM Interview WHERE interviewId = #{interviewId}
     </select>
 
+    <!-- userID 기반 인터뷰 내역 조회 -->
+    <select id="findInterviewsByUserId" resultType="com.graduation.interviewAi.domain.Interview">
+        SELECT
+            interviewId,
+            company,
+            jobId,
+            resumeId,
+            date AS createdAt,
+            userId
+        FROM Interview
+        WHERE userId = #{userId}
+        ORDER BY date DESC
+    </select>
+
+
 </mapper>

--- a/src/main/resources/mapper/ResultMapper.xml
+++ b/src/main/resources/mapper/ResultMapper.xml
@@ -27,7 +27,7 @@
                )
     </insert>
 
-    <!-- InterviewId 기반 결과 가져옴 -->
+    <!-- InterviewId 기반 결과 조회 -->
     <select id="findResultByInterviewId" resultType="com.graduation.interviewAi.domain.Result">
         SELECT
             resultId,
@@ -43,7 +43,7 @@
         WHERE interviewId = #{interviewId}
     </select>
 
-    <!-- userID 기반 점수 내역 가져옴-->
+    <!-- userID 기반 점수 내역 조회-->
     <select id="findScoreRecordsByInterviewId" resultType="com.graduation.interviewAi.dto.ScoreRecordsDto">
         SELECT
             r.interviewId,

--- a/src/main/resources/mapper/ResultMapper.xml
+++ b/src/main/resources/mapper/ResultMapper.xml
@@ -42,4 +42,20 @@
         FROM Result
         WHERE interviewId = #{interviewId}
     </select>
+
+    <!-- userID 기반 점수 내역 가져옴-->
+    <select id="findScoreRecordsByInterviewId" resultType="com.graduation.interviewAi.dto.ScoreRecordsDto">
+        SELECT
+            r.interviewId,
+            AVG(r.simScore) AS simScore,
+            AVG(r.logicScore) AS logicScore,
+            AVG(r.claScore) AS claScore,
+            MAX(r.createdAt) AS createdAt
+        FROM Result r
+                 JOIN Interview i ON r.interviewId = i.interviewId
+        WHERE i.userId = #{userId}
+        GROUP BY r.interviewId
+        ORDER BY MAX(r.createdAt) DESC
+    </select>
+
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈
#16 

userId기반의 인터뷰 결과 조회(논리성, 명확성, 유사성 평균, 날짜를 가져옴) 
-> 이를 이용해서 날짜별 점수 추이 시각화

userId기반의 인터뷰 ID와 Job 조회 후, Q&A 내역을 조회해서 가져옴 
-> 회사-직군별 Q&A 내역

## 📝작업 내용

- ResultMapper.xml
- InterviewMapper.xml
- ResultMapper.java
- InterviewMapper.java
- InterviewWithJobDto.java
- InterviewWithAnswerDto.java
- ScoreRecordsDto.java
- ResultService.java
- ResultController.java

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
